### PR TITLE
Make SimpleGridCells return empty list when size is invalid

### DIFF
--- a/grid/src/commonMain/kotlin/com/cheonjaeung/compose/grid/SimpleGridCells.kt
+++ b/grid/src/commonMain/kotlin/com/cheonjaeung/compose/grid/SimpleGridCells.kt
@@ -54,6 +54,10 @@ interface SimpleGridCells {
 
             val totalSpacing = spacing * (count - 1)
             val totalCellSize = availableSize - totalSpacing
+            if (totalCellSize <= 0) {
+                return emptyList()
+            }
+
             val cellSize = totalCellSize / count
             val remainingPixels = totalCellSize % count
             return List(count) { index ->
@@ -110,13 +114,21 @@ interface SimpleGridCells {
 
             val minSizePx = minSize.roundToPx()
             val minSizeWithSpacingPx = minSizePx + spacing
-            val count = if (minSizeWithSpacingPx != 0) {
+            val count = if (minSizeWithSpacingPx > 0) {
                 max((availableSize + spacing) / minSizeWithSpacingPx, 1)
             } else {
-                1
+                0
             }
+            if (count == 0) {
+                return emptyList()
+            }
+
             val totalSpacing = spacing * (count - 1)
             val totalCellSize = availableSize - totalSpacing
+            if (totalCellSize <= 0) {
+                return emptyList()
+            }
+
             val cellSize = totalCellSize / count
             val remainingPixels = totalCellSize % count
             return List(count) { index ->
@@ -178,14 +190,13 @@ interface SimpleGridCells {
             val cellSize = size.roundToPx()
             val availableSizeWithSpacing = availableSize + spacing
             val cellSizeWithSpacing = cellSize + spacing
+            if (cellSizeWithSpacing <= 0) {
+                return emptyList()
+            }
 
             return if (cellSizeWithSpacing < availableSizeWithSpacing) {
-                val count = if (cellSizeWithSpacing != 0) {
-                    availableSizeWithSpacing / cellSizeWithSpacing
-                } else {
-                    1
-                }
-                return List(count) { cellSize }
+                val count = availableSizeWithSpacing / cellSizeWithSpacing
+                List(count) { cellSize }
             } else {
                 List(1) { availableSize }
             }

--- a/grid/src/test/java/com/cheonjaeung/compose/grid/SimpleGridCellsAdaptiveTest.kt
+++ b/grid/src/test/java/com/cheonjaeung/compose/grid/SimpleGridCellsAdaptiveTest.kt
@@ -173,4 +173,19 @@ class SimpleGridCellsAdaptiveTest {
 
         assertEquals(emptyList<Int>(), cellSizes)
     }
+
+    @Test
+    fun testMinSizePlusSpacingIsZero() {
+        val adaptive = SimpleGridCells.Adaptive(50.dp)
+        val availableSize = 100
+        val spacing = -50
+
+        val cellSizes = with(adaptive) {
+            with(testDensity) {
+                calculateCrossAxisCellSizes(availableSize, spacing)
+            }
+        }
+
+        assertEquals(emptyList<Int>(), cellSizes)
+    }
 }

--- a/grid/src/test/java/com/cheonjaeung/compose/grid/SimpleGridCellsFixedSizeTest.kt
+++ b/grid/src/test/java/com/cheonjaeung/compose/grid/SimpleGridCellsFixedSizeTest.kt
@@ -174,4 +174,19 @@ class SimpleGridCellsFixedSizeTest {
 
         assertEquals(emptyList<Int>(), cellSizes)
     }
+
+    @Test
+    fun testZeroCellSize() {
+        val fixedSize = SimpleGridCells.FixedSize(30.dp)
+        val availableSize = 100
+        val spacing = -30
+
+        val cellSizes = with(fixedSize) {
+            with(testDensity) {
+                calculateCrossAxisCellSizes(availableSize, spacing)
+            }
+        }
+
+        assertEquals(emptyList<Int>(), cellSizes)
+    }
 }

--- a/grid/src/test/java/com/cheonjaeung/compose/grid/SimpleGridCellsFixedTest.kt
+++ b/grid/src/test/java/com/cheonjaeung/compose/grid/SimpleGridCellsFixedTest.kt
@@ -121,4 +121,19 @@ class SimpleGridCellsFixedTest {
 
         assertEquals(emptyList<Int>(), cellSizes)
     }
+
+    @Test
+    fun testZeroCellSize() {
+        val fixed = SimpleGridCells.Fixed(3)
+        val availableSize = 100
+        val spacing = 50
+
+        val cellSizes = with(fixed) {
+            with(testDensity) {
+                calculateCrossAxisCellSizes(availableSize, spacing)
+            }
+        }
+
+        assertEquals(emptyList<Int>(), cellSizes)
+    }
 }


### PR DESCRIPTION
- Add early return in the `SimpleGridCells.calculateCrossAxisCellSizes`.
  - If available size is 0 or negative, it returns empty list immediately. Because it means that there is no space to place items.
  - If calculated cell size is 0 or negative, it returns empty list. Because it means that cells are invisible.