### PR TITLE
Fix exception when using VerticalGrid or HorizontalGrid inside an unbounded container

### DIFF
--- a/grid/src/commonMain/kotlin/com/cheonjaeung/compose/grid/OrientationIndependentConstraints.kt
+++ b/grid/src/commonMain/kotlin/com/cheonjaeung/compose/grid/OrientationIndependentConstraints.kt
@@ -64,8 +64,11 @@ private fun packOrientationIndependentConstraints(
         "minSize must be less than or equal to maxSize"
     }
 
-    require(mainAxisMaxSizeValue < Infinity && crossAxisMaxSizeValue < Infinity) {
-        "size must be less than $Infinity"
+    require(
+        (mainAxisMaxSize == Constraints.Infinity || mainAxisMaxSize < Infinity) &&
+            (crossAxisMaxSize == Constraints.Infinity || crossAxisMaxSize < Infinity)
+    ) {
+        "size must be less than $Infinity or be Constraints.Infinity"
     }
 
     // Pack 4 integer sizes into 64 bits.
@@ -107,35 +110,34 @@ internal value class OrientationIndependentConstraints(val value: Long) {
      * The minimum size of the main axis in pixels.
      */
     val mainAxisMinSize: Int
-        get() = (value shr MainAxisMinSizeBitOffset).toInt() and UnpackMask
+        get() = unpackedSizeOrInfinity((value shr MainAxisMinSizeBitOffset).toInt() and UnpackMask)
 
     /**
      * The maximum size of the main axis in pixels.
      */
     val mainAxisMaxSize: Int
-        get() = (value shr MainAxisMaxSizeBitOffset).toInt() and UnpackMask
+        get() = unpackedSizeOrInfinity((value shr MainAxisMaxSizeBitOffset).toInt() and UnpackMask)
 
     /**
      * The minimum size of the cross axis in pixels.
      */
     val crossAxisMinSize: Int
-        get() = (value shr CrossAxisMinSizeBitOffset).toInt() and UnpackMask
+        get() = unpackedSizeOrInfinity((value shr CrossAxisMinSizeBitOffset).toInt() and UnpackMask)
 
     /**
      * The maximum size of the cross axis in pixels.
      */
     val crossAxisMaxSize: Int
-        get() = (value and UnpackMask.toLong()).toInt()
+        get() = unpackedSizeOrInfinity((value and UnpackMask.toLong()).toInt())
+
+    private fun unpackedSizeOrInfinity(value: Int): Int {
+        return if (value == Infinity) Constraints.Infinity else value
+    }
 
     /**
      * Convert this to original [Constraints] class based on the layout orientation.
      */
     fun toConstraints(orientation: LayoutOrientation): Constraints {
-        val mainAxisMinSize = if (mainAxisMinSize == Infinity) Constraints.Infinity else mainAxisMinSize
-        val mainAxisMaxSize = if (mainAxisMaxSize == Infinity) Constraints.Infinity else mainAxisMaxSize
-        val crossAxisMinSize = if (crossAxisMinSize == Infinity) Constraints.Infinity else crossAxisMinSize
-        val crossAxisMaxSize = if (crossAxisMaxSize == Infinity) Constraints.Infinity else crossAxisMaxSize
-
         return if (orientation == LayoutOrientation.Horizontal) {
             Constraints(
                 minWidth = mainAxisMinSize,
@@ -154,10 +156,10 @@ internal value class OrientationIndependentConstraints(val value: Long) {
     }
 
     override fun toString(): String {
-        val mainAxisMinStr = if (mainAxisMinSize == Infinity) "Infinity" else "$mainAxisMinSize"
-        val mainAxisMaxStr = if (mainAxisMaxSize == Infinity) "Infinity" else "$mainAxisMaxSize"
-        val crossAxisMinStr = if (crossAxisMinSize == Infinity) "Infinity" else "$crossAxisMinSize"
-        val crossAxisMaxStr = if (crossAxisMaxSize == Infinity) "Infinity" else "$crossAxisMaxSize"
+        val mainAxisMinStr = if (mainAxisMinSize == Constraints.Infinity) "Infinity" else "$mainAxisMinSize"
+        val mainAxisMaxStr = if (mainAxisMaxSize == Constraints.Infinity) "Infinity" else "$mainAxisMaxSize"
+        val crossAxisMinStr = if (crossAxisMinSize == Constraints.Infinity) "Infinity" else "$crossAxisMinSize"
+        val crossAxisMaxStr = if (crossAxisMaxSize == Constraints.Infinity) "Infinity" else "$crossAxisMaxSize"
 
         return "OrientationIndependentConstraints(" +
             "mainAxisMinSize=$mainAxisMinStr, " +

--- a/grid/src/commonMain/kotlin/com/cheonjaeung/compose/grid/OrientationIndependentConstraints.kt
+++ b/grid/src/commonMain/kotlin/com/cheonjaeung/compose/grid/OrientationIndependentConstraints.kt
@@ -57,18 +57,22 @@ private fun packOrientationIndependentConstraints(
     val crossAxisMaxSizeValue = if (crossAxisMaxSize == Constraints.Infinity) Infinity else crossAxisMaxSize
 
     require(mainAxisMinSize >= 0 && crossAxisMinSize >= 0) {
-        "size must be positive"
+        "size must be positive: " +
+            "mainAxisMinSize=$mainAxisMinSize, crossAxisMinSize=$crossAxisMinSize"
     }
 
     require(mainAxisMinSize <= mainAxisMaxSizeValue && crossAxisMinSize <= crossAxisMaxSizeValue) {
-        "minSize must be less than or equal to maxSize"
+        "minSize must be less than or equal to maxSize: " +
+            "mainAxisSize=(min=$mainAxisMinSize, max=$mainAxisMaxSize), " +
+            "crossAxisSize=(min=$crossAxisMinSize, max=$crossAxisMaxSize)"
     }
 
     require(
         (mainAxisMaxSize == Constraints.Infinity || mainAxisMaxSize < Infinity) &&
             (crossAxisMaxSize == Constraints.Infinity || crossAxisMaxSize < Infinity)
     ) {
-        "size must be less than $Infinity or be Constraints.Infinity"
+        "size must be less than $Infinity or equal to Infinity: " +
+            "mainAxisMaxSize=$mainAxisMaxSize, crossAxisMaxSize=$crossAxisMaxSize"
     }
 
     // Pack 4 integer sizes into 64 bits.

--- a/grid/src/test/java/com/cheonjaeung/compose/grid/OrientationIndependentConstraintsTest.kt
+++ b/grid/src/test/java/com/cheonjaeung/compose/grid/OrientationIndependentConstraintsTest.kt
@@ -1,0 +1,192 @@
+package com.cheonjaeung.compose.grid
+
+import androidx.compose.ui.unit.Constraints
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class OrientationIndependentConstraintsTest {
+    @Test
+    fun testFromConstraintsHorizontal() {
+        val source = Constraints(
+            minWidth = 100,
+            maxWidth = 1920,
+            minHeight = 50,
+            maxHeight = 1080,
+        )
+
+        val c = OrientationIndependentConstraints(LayoutOrientation.Horizontal, source)
+
+        assertEquals(100, c.mainAxisMinSize)
+        assertEquals(1920, c.mainAxisMaxSize)
+        assertEquals(50, c.crossAxisMinSize)
+        assertEquals(1080, c.crossAxisMaxSize)
+    }
+
+    @Test
+    fun testFromConstraintsVertical() {
+        val source = Constraints(
+            minWidth = 50,
+            maxWidth = 1080,
+            minHeight = 100,
+            maxHeight = 1920,
+        )
+
+        val c = OrientationIndependentConstraints(LayoutOrientation.Vertical, source)
+
+        assertEquals(100, c.mainAxisMinSize)
+        assertEquals(1920, c.mainAxisMaxSize)
+        assertEquals(50, c.crossAxisMinSize)
+        assertEquals(1080, c.crossAxisMaxSize)
+    }
+
+    @Test
+    fun testZeroConstraints() {
+        val c = OrientationIndependentConstraints(
+            mainAxisMinSize = 0,
+            mainAxisMaxSize = 0,
+            crossAxisMinSize = 0,
+            crossAxisMaxSize = 0,
+        )
+
+        assertEquals(0, c.mainAxisMinSize)
+        assertEquals(0, c.mainAxisMaxSize)
+        assertEquals(0, c.crossAxisMinSize)
+        assertEquals(0, c.crossAxisMaxSize)
+    }
+
+    @Test
+    fun testSameMinMaxConstraints() {
+        val c = OrientationIndependentConstraints(
+            mainAxisMinSize = 1920,
+            mainAxisMaxSize = 1920,
+            crossAxisMinSize = 1080,
+            crossAxisMaxSize = 1080,
+        )
+
+        assertEquals(1920, c.mainAxisMinSize)
+        assertEquals(1920, c.mainAxisMaxSize)
+        assertEquals(1080, c.crossAxisMinSize)
+        assertEquals(1080, c.crossAxisMaxSize)
+    }
+
+    @Test
+    fun testCreateWithInfinityMainAxisMaxSize() {
+        val c = OrientationIndependentConstraints(
+            mainAxisMinSize = 0,
+            mainAxisMaxSize = Constraints.Infinity,
+            crossAxisMinSize = 0,
+            crossAxisMaxSize = 1080,
+        )
+
+        val converted = c.toConstraints(LayoutOrientation.Vertical)
+        assertEquals(0, converted.minHeight)
+        assertEquals(Constraints.Infinity, converted.maxHeight)
+        assertEquals(0, converted.minWidth)
+        assertEquals(1080, converted.maxWidth)
+    }
+
+    @Test
+    fun testCreateWithInfinityCrossAxisMaxSize() {
+        val c = OrientationIndependentConstraints(
+            mainAxisMinSize = 0,
+            mainAxisMaxSize = 1920,
+            crossAxisMinSize = 0,
+            crossAxisMaxSize = Constraints.Infinity,
+        )
+
+        val converted = c.toConstraints(LayoutOrientation.Vertical)
+        assertEquals(0, converted.minHeight)
+        assertEquals(1920, converted.maxHeight)
+        assertEquals(0, converted.minWidth)
+        assertEquals(Constraints.Infinity, converted.maxWidth)
+    }
+
+    @Test
+    fun testFromConstraintsWithInfiniteWidth() {
+        val source = Constraints(
+            minWidth = 0,
+            maxWidth = Constraints.Infinity,
+            minHeight = 0,
+            maxHeight = 1920,
+        )
+
+        val c = OrientationIndependentConstraints(LayoutOrientation.Horizontal, source)
+
+        val converted = c.toConstraints(LayoutOrientation.Horizontal)
+        assertEquals(source.minWidth, converted.minWidth)
+        assertEquals(source.maxWidth, converted.maxWidth)
+        assertEquals(source.minHeight, converted.minHeight)
+        assertEquals(source.maxHeight, converted.maxHeight)
+    }
+
+    @Test
+    fun testFromConstraintsWithInfiniteHeight() {
+        val source = Constraints(
+            minWidth = 0,
+            maxWidth = 1080,
+            minHeight = 0,
+            maxHeight = Constraints.Infinity,
+        )
+
+        val c = OrientationIndependentConstraints(LayoutOrientation.Vertical, source)
+
+        val converted = c.toConstraints(LayoutOrientation.Vertical)
+        assertEquals(source.minWidth, converted.minWidth)
+        assertEquals(source.maxWidth, converted.maxWidth)
+        assertEquals(source.minHeight, converted.minHeight)
+        assertEquals(source.maxHeight, converted.maxHeight)
+    }
+
+    @Test
+    fun testCreateWithMaxFiniteSize() {
+        val c = OrientationIndependentConstraints(
+            mainAxisMinSize = 0,
+            mainAxisMaxSize = 65534,
+            crossAxisMinSize = 0,
+            crossAxisMaxSize = 65534,
+        )
+
+        assertEquals(65534, c.mainAxisMaxSize)
+        assertEquals(65534, c.crossAxisMaxSize)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testCreateWithMinSizeGreaterThanMaxSize() {
+        OrientationIndependentConstraints(
+            mainAxisMinSize = 200,
+            mainAxisMaxSize = 100,
+            crossAxisMinSize = 0,
+            crossAxisMaxSize = 100,
+        )
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testCreateWithTooLargeMainAxisSize() {
+        OrientationIndependentConstraints(
+            mainAxisMinSize = 0,
+            mainAxisMaxSize = 65535,
+            crossAxisMinSize = 0,
+            crossAxisMaxSize = 1080,
+        )
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testCreateWithTooLargeCrossAxisSize() {
+        OrientationIndependentConstraints(
+            mainAxisMinSize = 0,
+            mainAxisMaxSize = 1080,
+            crossAxisMinSize = 0,
+            crossAxisMaxSize = 65535,
+        )
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testCreateWithNegativeSize() {
+        OrientationIndependentConstraints(
+            mainAxisMinSize = -1,
+            mainAxisMaxSize = 100,
+            crossAxisMinSize = 0,
+            crossAxisMaxSize = 100,
+        )
+    }
+}


### PR DESCRIPTION
This fixes `IllegalArgumentException` that occurred when using `VerticalGrid` or `HorizontalGrid` inside an unbounded container such as `LazyColumn`.