### PR TITLE
Upgrade dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
-kotlin = "2.3.10"
+kotlin = "2.4.0"
 androidGradlePlugin = "8.13.2"
-composeMultiplatform = "1.10.0"
+composeMultiplatform = "1.11.1"
 
 [plugins]
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
@@ -17,17 +17,17 @@ maven-publish = { id = "com.vanniktech.maven.publish", version = "0.34.0" }
 
 [libraries]
 # Sample dependencies
-kotlinx-immutable-collections = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version = "0.4.0" }
-androidx-core = { module = "androidx.core:core", version = "1.17.0" }
+kotlinx-immutable-collections = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version = "0.5.1" }
+androidx-core = { module = "androidx.core:core", version = "1.18.0" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version = "1.7.1" }
-androidx-activity-compose = { module = "androidx.activity:activity-compose", version = "1.12.4" }
-compose-android-runtime = { module = "androidx.compose.runtime:runtime", version = "1.10.3" }
-compose-android-foundation = { module = "androidx.compose.foundation:foundation", version = "1.10.3" }
-compose-android-ui = { module = "androidx.compose.ui:ui", version = "1.10.3" }
+androidx-activity-compose = { module = "androidx.activity:activity-compose", version = "1.13.0" }
+compose-android-runtime = { module = "androidx.compose.runtime:runtime", version = "1.11.4" }
+compose-android-foundation = { module = "androidx.compose.foundation:foundation", version = "1.11.4" }
+compose-android-ui = { module = "androidx.compose.ui:ui", version = "1.11.4" }
 compose-android-material3 = { module = "androidx.compose.material3:material3", version = "1.4.0" }
 
 # Benchmark dependencies
 androidx-benchmark-junit4 = { module = "androidx.benchmark:benchmark-junit4", version = "1.4.1" }
 androidx-test-runner = { module = "androidx.test:runner", version = "1.7.0" }
-compose-android-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version = "1.10.6" }
-compose-android-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version = "1.10.6" }
+compose-android-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version = "1.11.4" }
+compose-android-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version = "1.11.4" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,11 +16,19 @@ paparazzi = { id = "app.cash.paparazzi", version = "2.0.0-alpha02" }
 maven-publish = { id = "com.vanniktech.maven.publish", version = "0.34.0" }
 
 [libraries]
+# Library dependencies
+compose-multiplatform-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "composeMultiplatform" }
+compose-multiplatform-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "composeMultiplatform" }
+compose-multiplatform-ui-util = { module = "org.jetbrains.compose.ui:ui-util", version.ref = "composeMultiplatform" }
+
 # Sample dependencies
 kotlinx-immutable-collections = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version = "0.5.1" }
 androidx-core = { module = "androidx.core:core", version = "1.18.0" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version = "1.7.1" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version = "1.13.0" }
+compose-multiplatform-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "composeMultiplatform" }
+compose-multiplatform-material3 = { module = "org.jetbrains.compose.material3:material3", version = "1.9.0" }
+compose-multiplatform-material-icons-extended = { module = "org.jetbrains.compose.material:material-icons-extended", version = "1.7.3" }
 compose-android-runtime = { module = "androidx.compose.runtime:runtime", version = "1.11.4" }
 compose-android-foundation = { module = "androidx.compose.foundation:foundation", version = "1.11.4" }
 compose-android-ui = { module = "androidx.compose.ui:ui", version = "1.11.4" }

--- a/grid/build.gradle.kts
+++ b/grid/build.gradle.kts
@@ -33,9 +33,9 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(compose.runtime)
-                implementation(compose.foundation)
-                implementation(compose.uiUtil)
+                implementation(libs.compose.multiplatform.runtime)
+                implementation(libs.compose.multiplatform.foundation)
+                implementation(libs.compose.multiplatform.ui.util)
             }
         }
     }

--- a/grid/build.gradle.kts
+++ b/grid/build.gradle.kts
@@ -13,7 +13,6 @@ kotlin {
     androidTarget()
 
     listOf(
-        iosX64(),
         iosArm64(),
         iosSimulatorArm64()
     ).forEach {

--- a/samples/shared/build.gradle.kts
+++ b/samples/shared/build.gradle.kts
@@ -33,11 +33,11 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(compose.runtime)
-                implementation(compose.foundation)
-                implementation(compose.ui)
-                implementation(compose.material3)
-                implementation(compose.materialIconsExtended)
+                implementation(libs.compose.multiplatform.runtime)
+                implementation(libs.compose.multiplatform.foundation)
+                implementation(libs.compose.multiplatform.ui)
+                implementation(libs.compose.multiplatform.material3)
+                implementation(libs.compose.multiplatform.material.icons.extended)
                 implementation(project(":grid"))
 
                 implementation(libs.kotlinx.immutable.collections)

--- a/samples/shared/build.gradle.kts
+++ b/samples/shared/build.gradle.kts
@@ -12,7 +12,6 @@ kotlin {
     androidTarget()
 
     listOf(
-        iosX64(),
         iosArm64(),
         iosSimulatorArm64()
     ).forEach {


### PR DESCRIPTION
Upgrade versions:
- Kotlin 2.3.10 -> 2.4.0
- Compose Multiplatform 1.10.0 -> 1.11.1

And, convert dependency notations to version catalogs, because compose Multiplatform supports are deprecated.

iOSX64 target is removed. Compose Multiplatform 1.11 no longer supports it.
